### PR TITLE
URL validation before creating shortlink

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -39,6 +39,15 @@ async function handlePOST(request) {
 	if (!redirectURL || !path)
 		return new Response('`url` and `path` need to be set.', { status: 400 });
 
+	// validate redirectURL is a URL
+	try {
+		new URL(redirectURL);
+	} catch (e) {
+		if (e instanceof TypeError) 
+			return new Response('`url` needs to be a valid http url.', { status: 400 });
+		else throw e;
+	};
+
 	// will overwrite current path if it exists
 	await LINKS.put(path, redirectURL);
 	return new Response(`${redirectURL} available at ${shortener}${path}`, {


### PR DESCRIPTION
Calls the URL object constructor which would throw a type error if it is not a valid url (including if it doesn't begin with a protocol).

Saves us from using regex